### PR TITLE
panel: updates

### DIFF
--- a/panels/meson.build
+++ b/panels/meson.build
@@ -32,6 +32,7 @@ panels = [
   'user-accounts',
   'windows',
   'wwan',
+  'updates',
 ]
 
 if host_is_linux

--- a/panels/updates/cc-tariff-editor.c
+++ b/panels/updates/cc-tariff-editor.c
@@ -1,0 +1,579 @@
+/* cc-tariff-editor.c
+ *
+ * Copyright © 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cc-tariff-editor.h"
+
+#include <gdesktop-enums.h>
+#include <libmogwai-tariff/tariff-builder.h>
+
+#define CLOCK_SCHEMA     "org.gnome.desktop.interface"
+#define CLOCK_FORMAT_KEY "clock-format"
+
+struct _CcTariffEditor
+{
+  GtkGrid             parent;
+
+  GtkWidget           *button_from_am;
+  GtkWidget           *button_from_pm;
+  GtkWidget           *spinbutton_from_hours;
+  GtkWidget           *spinbutton_from_minutes;
+  GtkWidget           *blank_from;
+  GtkWidget           *button_to_am;
+  GtkWidget           *button_to_pm;
+  GtkWidget           *spinbutton_to_hours;
+  GtkWidget           *spinbutton_to_minutes;
+  GtkWidget           *blank_to;
+  GtkWidget           *stack_from;
+  GtkWidget           *stack_to;
+
+  //AdwActionRow        *software_updates_row;
+
+  GtkAdjustment       *adjustment_from_hours;
+  GtkAdjustment       *adjustment_from_minutes;
+  GtkAdjustment       *adjustment_to_hours;
+  GtkAdjustment       *adjustment_to_minutes;
+
+  GVariant            *tariff_as_variant;  /* (nullable) */
+
+  /* Clock format */
+  GSettings           *settings_clock;
+  GDesktopClockFormat  clock_format;
+
+  guint8               time_period_from;
+  guint8               time_period_to;
+
+  /* Always in UTC */
+  guint64              seconds_to_start;
+  guint64              seconds_to_end;
+};
+
+G_DEFINE_TYPE (CcTariffEditor, cc_tariff_editor, GTK_TYPE_GRID)
+
+G_DEFINE_QUARK (CcTariffEditorError, cc_tariff_editor_error)
+
+enum
+{
+  TARIFF_CHANGED,
+  LAST_SIGNAL
+};
+
+enum
+{
+  AM,
+  PM,
+};
+
+
+static void on_time_changed_cb (CcTariffEditor *self);
+
+
+static guint signals[LAST_SIGNAL] = { 0, };
+
+
+/*
+ * Auxiliary methods
+ */
+
+static gint
+get_am_hour (GDateTime *dt)
+{
+  if (g_date_time_get_hour (dt) % 12 == 0)
+    return 12;
+
+  return g_date_time_get_hour (dt) % 12;
+}
+
+static void
+update_seconds_from_adjustments (CcTariffEditor *self)
+{
+  g_autoptr(GDateTime) local_start = NULL;
+  g_autoptr(GDateTime) local_end = NULL;
+  gint minute_start = 0;
+  gint minute_end = 0;
+  gint hour_start = 0;
+  gint hour_end = 0;
+
+  hour_start = (gint) gtk_adjustment_get_value (self->adjustment_from_hours);
+  hour_end = (gint) gtk_adjustment_get_value (self->adjustment_to_hours);
+  minute_start = (gint) gtk_adjustment_get_value (self->adjustment_from_minutes);
+  minute_end = (gint) gtk_adjustment_get_value (self->adjustment_to_minutes);
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
+    {
+      hour_start = hour_start % 12 + (self->time_period_from == AM ? 0 : 12);
+      hour_end = hour_end % 12 + (self->time_period_to == AM ? 0 : 12);
+    }
+
+  /* Use 2nd January 1970 so that there’s no chance of doing before UNIX
+   * timestamp 0 if the local timezone has a large negative offset. */
+  local_start = g_date_time_new_local (1970, 1, 2, hour_start, minute_start, 0);
+  local_end = g_date_time_new_local (1970, 1, 2, hour_end, minute_end, 0);
+
+  /*
+   * If 'from' > 'to', e.g. [22:15, 05:45), this period is crossing days and we
+   * need to add +1 day to the end date. Otherwise, e.g, [13:10, 19:15), the period
+   * is contained in a single day, and we don't need to do anything.
+   */
+  if (g_date_time_compare (local_start, local_end) >= 0)
+    {
+      g_autoptr(GDateTime) new_local_end = g_date_time_add_days (local_end, 1);
+      g_clear_pointer (&local_end, g_date_time_unref);
+      local_end = g_steal_pointer (&new_local_end);
+    }
+
+  self->seconds_to_start = g_date_time_to_unix (local_start);
+  self->seconds_to_end = g_date_time_to_unix (local_end);
+}
+
+static gboolean
+setup_tariff (CcTariffEditor  *self,
+              MwtTariff       *tariff,
+              GError         **error)
+{
+  g_autoptr(GDateTime) maximum_date = NULL;
+  GDateTime *period_start, *period_end;
+  MwtPeriod *base_period, *period;
+  GPtrArray *periods;
+
+  if (!tariff)
+    return FALSE;
+
+  /*
+   * Right now, it only parses the same kind of tariff it generates, a tariff
+   * with these 2 periods:
+   *
+   *  1 → forbidden downloads period
+   *  2 → allowed downloads period
+   *
+   * Anything that does not comform to that is ignored.
+   */
+
+  periods = mwt_tariff_get_periods (tariff);
+
+  if (periods->len != 2)
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_NOT_SUPPORTED,
+                   "Cannot parse complex tariffs yet");
+      return FALSE;
+    }
+
+  /* Validate and setup the forbidden downloads period */
+  maximum_date = g_date_time_new_utc (9999, 12, 31, 23 , 59, 59);
+  base_period = g_ptr_array_index (periods, 0);
+  period = g_ptr_array_index (periods, 1);
+
+  if (mwt_period_get_repeat_type (base_period) != MWT_PERIOD_REPEAT_NONE ||
+      g_date_time_to_unix (mwt_period_get_start (base_period)) != 0 ||
+      g_date_time_to_unix (mwt_period_get_end (base_period)) != g_date_time_to_unix (maximum_date))
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+                   "Base tariff is wrong");
+      return FALSE;
+    }
+
+  if (mwt_period_get_repeat_type (period) != MWT_PERIOD_REPEAT_DAY ||
+      mwt_period_get_repeat_period (period) != 1)
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+                   "Repeating period is wrong");
+      return FALSE;
+    }
+
+  g_signal_handlers_block_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_from_minutes, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_to_minutes, on_time_changed_cb, self);
+
+  period_start = mwt_period_get_start (period);
+  period_end = mwt_period_get_end (period);
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_adjustment_set_value (self->adjustment_from_hours, g_date_time_get_hour (period_start));
+      gtk_adjustment_set_value (self->adjustment_from_minutes, g_date_time_get_minute (period_start));
+      gtk_adjustment_set_value (self->adjustment_to_hours, g_date_time_get_hour (period_end));
+      gtk_adjustment_set_value (self->adjustment_to_minutes, g_date_time_get_minute (period_end));
+    }
+  else
+    {
+      self->time_period_from = g_date_time_get_hour (period_start) < 12 ? AM : PM;
+      self->time_period_to = g_date_time_get_hour (period_end) < 12 ? AM : PM;
+
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_from), self->time_period_from == AM ? GTK_WIDGET (self->button_from_am) : GTK_WIDGET (self->button_from_pm));
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_to), self->time_period_to == AM ? GTK_WIDGET (self->button_to_am) : GTK_WIDGET (self->button_to_pm));
+
+      gtk_adjustment_set_value (self->adjustment_from_hours, get_am_hour (period_start));
+      gtk_adjustment_set_value (self->adjustment_to_hours, get_am_hour (period_end));
+      gtk_adjustment_set_value (self->adjustment_from_minutes, g_date_time_get_minute (period_start));
+      gtk_adjustment_set_value (self->adjustment_to_minutes, g_date_time_get_minute (period_end));
+    }
+
+  g_signal_handlers_unblock_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_from_minutes, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_to_minutes, on_time_changed_cb, self);
+
+  return TRUE;
+}
+
+static void
+update_tariff (CcTariffEditor *self,
+               gboolean        should_notify)
+{
+  g_autoptr(MwtTariffBuilder) tariff_builder = NULL;
+  g_autoptr(MwtPeriod) forbidden_period = NULL;
+  g_autoptr(GDateTime) forbidden_start = NULL;
+  g_autoptr(GDateTime) forbidden_end = NULL;
+  g_autoptr(MwtPeriod) allowed_period = NULL;
+  g_autoptr(GDateTime) allowed_start = NULL;
+  g_autoptr(GDateTime) allowed_end = NULL;
+
+  /*
+   *  This is the a very simple implementation of a tariff, with 2 defined
+   * periods:
+   *
+   *  1. Forbidden: [0, forever), downloads are forbidden.
+   *  2. Allowed: [start hour, end hour) daily, downloads are allowed.
+   *
+   * Period 1 is in UTC because it covers all time, so we don’t need to worry
+   * about the timezone of the start and end, or recurrences. Period 2 is in
+   * the local timezone, so that the recurrences which fall within daylight
+   * savings still happen at the same hour of the day for the user.
+   */
+
+  tariff_builder = mwt_tariff_builder_new ();
+  mwt_tariff_builder_set_name (tariff_builder, "System Tariff");
+
+  update_seconds_from_adjustments (self);
+
+  /* 1. Forbidden downloads period */
+  forbidden_start = g_date_time_new_from_unix_utc (0);
+  forbidden_end = g_date_time_new_utc (9999, 12, 31, 23 , 59, 59);
+  forbidden_period = mwt_period_new (forbidden_start,
+                                     forbidden_end,
+                                     MWT_PERIOD_REPEAT_NONE, 0,
+                                     "capacity-limit", 0,
+                                     NULL);
+
+  g_assert (forbidden_start != NULL);
+  g_assert (forbidden_end != NULL);
+
+  mwt_tariff_builder_add_period (tariff_builder, forbidden_period);
+
+  /* 2. Allowed downloads period */
+  allowed_start = g_date_time_new_from_unix_local (self->seconds_to_start);
+  allowed_end = g_date_time_new_from_unix_local (self->seconds_to_end);
+
+  g_assert (allowed_start != NULL);
+  g_assert (allowed_end != NULL);
+
+  allowed_period = mwt_period_new (allowed_start,
+                                   allowed_end,
+                                   MWT_PERIOD_REPEAT_DAY, 1,
+                                   "capacity-limit", G_MAXUINT64,
+                                   NULL);
+
+  mwt_tariff_builder_add_period (tariff_builder, allowed_period);
+
+  /* Store the new tariff */
+  g_clear_pointer (&self->tariff_as_variant, g_variant_unref);
+  self->tariff_as_variant = mwt_tariff_builder_get_tariff_as_variant (tariff_builder);
+
+  if (!self->tariff_as_variant)
+    g_critical ("Error building tariff");
+  else if (should_notify)
+    g_signal_emit (self, signals[TARIFF_CHANGED], 0);
+}
+
+static void
+update_adjustments (CcTariffEditor *self)
+{
+  g_autoptr(GDateTime) start = NULL;
+  g_autoptr(GDateTime) end = NULL;
+
+  g_debug ("Updating adjustments");
+
+  start = g_date_time_new_from_unix_local (self->seconds_to_start);
+  end = g_date_time_new_from_unix_local (self->seconds_to_end);
+
+  g_signal_handlers_block_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+
+  /* update spinbuttons */
+  gtk_spin_button_update (GTK_SPIN_BUTTON (self->spinbutton_from_hours));
+  gtk_spin_button_update (GTK_SPIN_BUTTON (self->spinbutton_to_hours));
+
+  /* From */
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_from), GTK_WIDGET (self->blank_from));
+
+      gtk_adjustment_set_lower (self->adjustment_from_hours, 0);
+      gtk_adjustment_set_upper (self->adjustment_from_hours, 23);
+
+      gtk_adjustment_set_value (self->adjustment_from_hours, g_date_time_get_hour (start));
+    }
+  else
+    {
+      self->time_period_from = gtk_adjustment_get_value (self->adjustment_from_hours) < 12 ? AM : PM;
+
+      if (self->time_period_from == AM)
+        gtk_stack_set_visible_child (GTK_STACK (self->stack_from), GTK_WIDGET (self->button_from_am));
+      else
+        gtk_stack_set_visible_child (GTK_STACK (self->stack_from), GTK_WIDGET (self->button_from_pm));
+
+      gtk_adjustment_set_lower (self->adjustment_from_hours, 1);
+      gtk_adjustment_set_upper (self->adjustment_from_hours, 12);
+
+      gtk_adjustment_set_value (self->adjustment_from_hours, get_am_hour (start));
+    }
+
+  /* To */
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_to), GTK_WIDGET (self->blank_to));
+
+      gtk_adjustment_set_lower (self->adjustment_to_hours, 0);
+      gtk_adjustment_set_upper (self->adjustment_to_hours, 23);
+
+      gtk_adjustment_set_value (self->adjustment_to_hours, g_date_time_get_hour (end));
+    }
+  else
+    {
+      self->time_period_to = gtk_adjustment_get_value (self->adjustment_to_hours) < 12 ? AM : PM;
+
+      if (self->time_period_to == AM)
+        gtk_stack_set_visible_child (GTK_STACK (self->stack_to), GTK_WIDGET (self->button_to_am));
+      else
+        gtk_stack_set_visible_child (GTK_STACK (self->stack_to), GTK_WIDGET (self->button_to_pm));
+
+      gtk_adjustment_set_lower (self->adjustment_to_hours, 1);
+      gtk_adjustment_set_upper (self->adjustment_to_hours, 12);
+
+      gtk_adjustment_set_value (self->adjustment_to_hours, get_am_hour (end));
+    }
+
+  g_signal_handlers_unblock_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+}
+
+
+/*
+ * Callbacks
+ */
+
+static void
+on_clock_settings_changed_cb (GSettings      *settings_display,
+                              gchar          *key,
+                              CcTariffEditor *self)
+{
+  self->clock_format = g_settings_get_enum (settings_display, CLOCK_FORMAT_KEY);
+
+  update_adjustments (self);
+}
+
+static gboolean
+on_hours_output_cb (GtkSpinButton  *spin,
+                    CcTariffEditor *self)
+{
+  GtkAdjustment *adjustment;
+  g_autofree gchar *text = NULL;
+
+  adjustment = gtk_spin_button_get_adjustment (spin);
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
+    text = g_strdup_printf ("%.0f", gtk_adjustment_get_value (adjustment));
+  else
+    text = g_strdup_printf ("%02.0f", gtk_adjustment_get_value (adjustment));
+
+  gtk_editable_set_text (GTK_EDITABLE (spin), text);
+
+  return TRUE;
+}
+
+static gboolean
+on_minutes_output_cb (GtkSpinButton  *spin,
+                      CcTariffEditor *self)
+{
+  GtkAdjustment *adjustment;
+  g_autofree gchar *text = NULL;
+
+  adjustment = gtk_spin_button_get_adjustment (spin);
+
+  text = g_strdup_printf ("%02.0f", gtk_adjustment_get_value (adjustment));
+  gtk_editable_set_text (GTK_EDITABLE (spin), text);
+
+  return TRUE;
+}
+
+static void
+on_time_changed_cb (CcTariffEditor *self)
+{
+  update_tariff (self, TRUE);
+}
+
+static void
+on_time_period_from_clicked_cb (GtkButton      *button,
+                                CcTariffEditor *self)
+{
+  if (self->time_period_from == AM)
+    {
+      self->time_period_from = PM;
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_from), GTK_WIDGET (self->button_from_pm));
+    }
+  else
+    {
+      self->time_period_from = AM;
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_from), GTK_WIDGET (self->button_from_am));
+    }
+}
+
+static void
+on_time_period_to_clicked_cb (GtkButton      *button,
+                              CcTariffEditor *self)
+{
+  if (self->time_period_to == AM)
+    {
+      self->time_period_to = PM;
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_to), GTK_WIDGET (self->button_to_pm));
+    }
+  else
+    {
+      self->time_period_to = AM;
+      gtk_stack_set_visible_child (GTK_STACK (self->stack_to), GTK_WIDGET (self->button_to_am));
+    }
+}
+
+
+/*
+ * GObject overrides
+ */
+
+static void
+cc_tariff_editor_finalize (GObject *object)
+{
+  CcTariffEditor *self = (CcTariffEditor *)object;
+
+  g_clear_object (&self->settings_clock);
+  g_clear_pointer (&self->tariff_as_variant, g_variant_unref);
+
+  G_OBJECT_CLASS (cc_tariff_editor_parent_class)->finalize (object);
+}
+
+
+static void
+cc_tariff_editor_class_init (CcTariffEditorClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->finalize = cc_tariff_editor_finalize;
+
+  signals[TARIFF_CHANGED] = g_signal_new ("tariff-changed",
+                                          CC_TYPE_TARIFF_EDITOR,
+                                          G_SIGNAL_RUN_FIRST,
+                                          0, NULL, NULL, NULL,
+                                          G_TYPE_NONE,
+                                          0);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/updates/cc-tariff-editor.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_from_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_from_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_to_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_to_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, stack_from);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, stack_to);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, button_from_am);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, button_from_pm);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, spinbutton_from_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, spinbutton_from_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, blank_from);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, button_to_am);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, button_to_pm);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, spinbutton_to_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, spinbutton_to_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, blank_to);
+
+  gtk_widget_class_bind_template_callback (widget_class, on_hours_output_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_minutes_output_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_period_from_clicked_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_period_to_clicked_cb);
+}
+
+static void
+cc_tariff_editor_init (CcTariffEditor *self)
+{
+  const guint64 one_day_in_seconds = 24 * 60 * 60;
+
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* Hardcode the default hours (22:00 and 6:00), adding a 24h buffer to ensure
+   * any large negative local timezone offsets don’t shift the UNIX timestamps
+   * below 0. */
+  self->seconds_to_start = 22 * 60 * 60 + one_day_in_seconds;
+  self->seconds_to_end = (6 + 24) * 60 * 60 + one_day_in_seconds;
+
+  /* Clock settings */
+  self->settings_clock = g_settings_new (CLOCK_SCHEMA);
+  self->clock_format = g_settings_get_enum (self->settings_clock, CLOCK_FORMAT_KEY);
+
+  update_adjustments (self);
+
+  g_signal_connect (self->settings_clock,
+                    "changed::"CLOCK_FORMAT_KEY,
+                    G_CALLBACK (on_clock_settings_changed_cb),
+                    self);
+
+  update_tariff (self, FALSE);
+}
+
+/**
+ * cc_tariff_editor_get_tariff_as_variant:
+ * @self: a #CcTariffEditor
+ *
+ * Gets the #GVariant form of the tariff currently set in the UI.
+ *
+ * Returns: (transfer none) (nullable): the tariff, or %NULL if no valid tariff
+ *     is set
+ */
+GVariant*
+cc_tariff_editor_get_tariff_as_variant (CcTariffEditor *self)
+{
+  g_return_val_if_fail (CC_IS_TARIFF_EDITOR (self), NULL);
+
+  return self->tariff_as_variant;
+}
+
+void
+cc_tariff_editor_load_tariff (CcTariffEditor  *self,
+                              MwtTariff       *tariff,
+                              GError         **error)
+{
+  g_return_if_fail (CC_IS_TARIFF_EDITOR (self));
+
+  if (setup_tariff (self, tariff, error))
+    update_tariff (self, FALSE);
+}

--- a/panels/updates/cc-tariff-editor.h
+++ b/panels/updates/cc-tariff-editor.h
@@ -1,0 +1,46 @@
+/* cc-tariff-editor.c
+ *
+ * Copyright © 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <libmogwai-tariff/tariff.h>
+
+G_BEGIN_DECLS
+
+typedef enum
+{
+  CC_TARIFF_EDITOR_ERROR_NOT_SUPPORTED,
+  CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+} CcTariffEditorError;
+
+#define CC_TARIFF_EDITOR_ERROR (cc_tariff_editor_error_quark ())
+#define CC_TYPE_TARIFF_EDITOR  (cc_tariff_editor_get_type())
+
+G_DECLARE_FINAL_TYPE (CcTariffEditor, cc_tariff_editor, CC, TARIFF_EDITOR, GtkGrid)
+
+GQuark    cc_tariff_editor_error_quark           (void);
+
+GVariant* cc_tariff_editor_get_tariff_as_variant (CcTariffEditor  *self);
+
+void      cc_tariff_editor_load_tariff           (CcTariffEditor  *self,
+                                                  MwtTariff       *tariff,
+                                                  GError         **error);
+
+G_END_DECLS

--- a/panels/updates/cc-tariff-editor.ui
+++ b/panels/updates/cc-tariff-editor.ui
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="CcTariffEditor" parent="GtkGrid">
+    <property name="column-homogeneous">True</property>
+    <property name="column-spacing">24</property>
+    <property name="row-spacing">12</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-top">12</property>
+    <property name="margin-bottom">12</property>
+
+    <!-- Start time -->
+    <child>
+      <object class="GtkLabel">
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">From</property>
+        <layout>
+          <property name="column">0</property>
+          <property name="row">0</property>
+        </layout>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">horizontal</property>
+        <property name="spacing">8</property>
+        <property name="halign">start</property>
+        <child>
+          <object class="GtkSpinButton" id="spinbutton_from_hours">
+            <property name="can_focus">True</property>
+            <property name="max_width_chars">2</property>
+            <property name="text">4</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_from_hours</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+            <property name="value">4</property>
+            <signal name="output" handler="on_hours_output_cb" object="CcTariffEditor" swapped="no" />
+            <style>
+              <class name="padded-spinbutton"/>
+            </style>
+            <accessibility>
+              <property name="description" translatable="yes">Hour</property>
+            </accessibility>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">:</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="spinbutton_from_minutes">
+            <property name="can_focus">True</property>
+            <property name="max_width_chars">2</property>
+            <property name="text">0</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_from_minutes</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+            <signal name="output" handler="on_minutes_output_cb" object="CcTariffEditor" swapped="no" />
+            <style>
+              <class name="padded-spinbutton"/>
+            </style>
+            <accessibility>
+              <property name="description" translatable="yes">Minute</property>
+            </accessibility>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="stack_from">
+            <property name="hhomogeneous">False</property>
+            <property name="vhomogeneous">False</property>
+            <child>
+              <object class="GtkButton" id="button_from_am">
+                <property name="label" translatable="yes" comments="This is the short form for the time period in the morning">AM</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_time_period_from_clicked_cb" object="CcTariffEditor" swapped="no" />
+                <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+                <style>
+                  <class name="unpadded-button"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_from_pm">
+                <property name="label" translatable="yes" comments="This is the short form for the time period in the afternoon">PM</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_time_period_from_clicked_cb" object="CcTariffEditor" swapped="no" />
+                <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+                <style>
+                  <class name="unpadded-button"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="blank_from">
+                <property name="can_focus">False</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <layout>
+          <property name="column">0</property>
+          <property name="row">1</property>
+        </layout>
+      </object>
+    </child>
+
+    <!-- End time -->
+    <child>
+      <object class="GtkLabel">
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">To</property>
+        <layout>
+          <property name="column">1</property>
+          <property name="row">0</property>
+        </layout>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">horizontal</property>
+        <property name="spacing">8</property>
+        <property name="halign">end</property>
+        <child>
+          <object class="GtkSpinButton" id="spinbutton_to_hours">
+            <property name="can_focus">True</property>
+            <property name="max_width_chars">2</property>
+            <property name="text">4</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_to_hours</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+            <property name="value">4</property>
+            <signal name="output" handler="on_hours_output_cb" object="CcTariffEditor" swapped="no" />
+            <style>
+              <class name="padded-spinbutton"/>
+            </style>
+            <accessibility>
+              <property name="description" translatable="yes">Hour</property>
+            </accessibility>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">:</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="spinbutton_to_minutes">
+            <property name="can_focus">True</property>
+            <property name="max_width_chars">2</property>
+            <property name="text">0</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_to_minutes</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+            <signal name="output" handler="on_minutes_output_cb" object="CcTariffEditor" swapped="no" />
+            <style>
+              <class name="padded-spinbutton"/>
+            </style>
+            <accessibility>
+              <property name="description" translatable="yes">Minute</property>
+            </accessibility>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="stack_to">
+            <property name="hhomogeneous">False</property>
+            <property name="vhomogeneous">False</property>
+            <child>
+              <object class="GtkButton" id="button_to_am">
+                <property name="label" translatable="yes" comments="This is the short form for the time period in the morning">AM</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_time_period_to_clicked_cb" object="CcTariffEditor" swapped="no" />
+                <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+                <style>
+                  <class name="unpadded-button"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_to_pm">
+                <property name="label" translatable="yes" comments="This is the short form for the time period in the afternoon">PM</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_time_period_to_clicked_cb" object="CcTariffEditor" swapped="no" />
+                <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+                <style>
+                  <class name="unpadded-button"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="blank_to">
+                <property name="can_focus">False</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <layout>
+          <property name="column">1</property>
+          <property name="row">1</property>
+        </layout>
+      </object>
+    </child>
+        
+
+  </template>
+
+  <!-- Adjustments for the spinners -->
+  <object class="GtkAdjustment" id="adjustment_from_hours">
+    <property name="value">22</property>
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_from_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_to_hours">
+    <property name="value">6</property>
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_to_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+</interface>

--- a/panels/updates/cc-updates-panel.c
+++ b/panels/updates/cc-updates-panel.c
@@ -1,0 +1,809 @@
+/* cc-updates-panel.c
+ *
+ * Copyright © 2018 Endless, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Georges Basile Stavracas Neto <georges@endlessm.com>
+ */
+
+#include "cc-tariff-editor.h"
+#include "cc-updates-panel.h"
+#include "cc-updates-resources.h"
+
+#include <glib/gi18n.h>
+#include <adwaita.h>
+#include <libmogwai-tariff/tariff-loader.h>
+#include <NetworkManager.h>
+
+#define NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED "connection.allow-downloads-when-metered"
+#define NM_SETTING_ALLOW_DOWNLOADS              "connection.allow-downloads"
+#define NM_SETTING_TARIFF_ENABLED               "connection.tariff-enabled"
+#define NM_SETTING_TARIFF                       "connection.tariff"
+
+struct _CcUpdatesPanel
+{
+  CcPanel             parent;
+
+  GtkWidget          *automatic_updates_row;
+  GtkWidget          *automatic_updates_switch;
+  GtkWidget          *network_settings_label;
+  GtkWidget          *network_status_icon;
+  AdwActionRow       *network_row;
+  GtkWidget          *scheduled_updates_switch;
+  CcTariffEditor     *tariff_editor;
+
+  /* Network Manager */
+  NMClient           *nm_client;
+  gulong              nm_client_notify_id;
+  NMDevice           *current_device;
+  NMConnection       *current_connection;
+
+  /* Signal handlers */
+  gulong              changed_id;
+  gulong              connection_changed_id;
+  guint               save_tariff_timeout_id;
+
+  GCancellable       *cancellable;
+};
+
+
+static void          on_automatic_updates_switch_changed_cb      (GtkSwitch      *sw,
+                                                                  GParamSpec     *pspec,
+                                                                  CcUpdatesPanel *self);
+
+static void          on_network_changed_cb                       (CcUpdatesPanel *self);
+
+static void          on_network_changes_committed_cb             (GObject        *source,
+                                                                  GAsyncResult   *result,
+                                                                  gpointer        user_data);
+
+static void          on_scheduled_updates_switch_changed_cb      (GtkSwitch      *sw,
+                                                                  GParamSpec     *pspec,
+                                                                  CcUpdatesPanel *self);
+
+static void          on_tariff_changed_cb                        (CcTariffEditor *tariff_editor,
+                                                                  CcUpdatesPanel *self);
+
+static gboolean      save_tariff_cb                              (gpointer        user_data);
+
+G_DEFINE_TYPE (CcUpdatesPanel, cc_updates_panel, CC_TYPE_PANEL)
+
+enum
+{
+  PROP_PARAMETERS = 1,
+  N_PROPS
+};
+
+
+/*
+ * Auxiliary methods
+ */
+
+static void
+cleanup_signals (CcUpdatesPanel *self)
+{
+  if (self->changed_id > 0)
+    {
+      g_signal_handler_disconnect (self->current_device, self->changed_id);
+      self->changed_id = 0;
+    }
+
+  if (self->connection_changed_id > 0)
+    {
+      g_signal_handler_disconnect (self->current_connection, self->connection_changed_id);
+      self->connection_changed_id = 0;
+    }
+
+  g_clear_object (&self->current_device);
+  g_clear_object (&self->current_connection);
+}
+
+static NMSettingConnection *
+ensure_setting_connection (NMConnection *connection)
+{
+  NMSettingConnection *setting = nm_connection_get_setting_connection (connection);
+
+  g_assert (connection != NULL);
+
+  if (!setting)
+    {
+      setting = NM_SETTING_CONNECTION (nm_setting_connection_new ());
+      nm_connection_add_setting (connection, NM_SETTING (setting));
+    }
+
+  return setting;
+}
+
+static NMSettingUser *
+ensure_setting_user (NMConnection *connection)
+{
+  NMSettingUser *setting_user;
+
+  g_assert (connection != NULL);
+
+  setting_user = NM_SETTING_USER (nm_connection_get_setting (connection, NM_TYPE_SETTING_USER));
+
+  if (!setting_user)
+    {
+      setting_user = NM_SETTING_USER (nm_setting_user_new ());
+      nm_connection_add_setting (connection, NM_SETTING (setting_user));
+    }
+
+  return setting_user;
+}
+
+static void
+store_automatic_updates_setting (CcUpdatesPanel *self,
+                                 NMConnection   *connection,
+                                 gboolean        automatic_updates_enabled,
+                                 gboolean        tariff_enabled,
+                                 GVariant       *tariff_variant  /* (nullable) */)
+{
+  NMSettingUser *setting_user;
+  g_autofree gchar *tariff_string = NULL;
+  g_autoptr(GError) error = NULL;
+  gboolean errored = FALSE;
+  gboolean allow_downloads_when_metered = TRUE;
+
+  setting_user = ensure_setting_user (connection);
+  g_assert (setting_user != NULL);
+
+  /* Calling nm_setting_user_set_data() causes notifications from NM. */
+  if (self->current_device && self->changed_id)
+    g_signal_handler_block (self->current_device, self->changed_id);
+  if (self->current_connection && self->connection_changed_id)
+    g_signal_handler_block (self->current_connection, self->connection_changed_id);
+
+  g_debug ("Setting "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED" to 1");
+
+  nm_setting_user_set_data (setting_user,
+                            NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED,
+                            allow_downloads_when_metered ? "1" : "0",
+                            &error);
+
+  if (error)
+    {
+      g_warning ("Error storing "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED": %s", error->message);
+      g_clear_error (&error);
+      errored = TRUE;
+    }
+
+  g_debug ("Setting "NM_SETTING_ALLOW_DOWNLOADS" to %d", automatic_updates_enabled);
+
+  nm_setting_user_set_data (setting_user,
+                            NM_SETTING_ALLOW_DOWNLOADS,
+                            automatic_updates_enabled ? "1" : "0",
+                            &error);
+
+  if (error)
+    {
+      g_warning ("Error storing "NM_SETTING_ALLOW_DOWNLOADS": %s", error->message);
+      g_clear_error (&error);
+      errored = TRUE;
+    }
+
+  g_debug ("Setting "NM_SETTING_TARIFF_ENABLED" to %d", tariff_enabled);
+
+  nm_setting_user_set_data (setting_user,
+                            NM_SETTING_TARIFF_ENABLED,
+                            tariff_enabled ? "1" : "0",
+                            &error);
+  if (error)
+    {
+      g_warning ("Error storing "NM_SETTING_TARIFF_ENABLED": %s", error->message);
+      g_clear_error (&error);
+      errored = TRUE;
+    }
+
+  tariff_string = tariff_variant ? g_variant_print (tariff_variant, TRUE) : NULL;
+
+  g_debug ("Setting "NM_SETTING_TARIFF" to %s", tariff_string);
+  nm_setting_user_set_data (setting_user, NM_SETTING_TARIFF, tariff_string, &error);
+
+  if (error)
+    {
+      g_warning ("Error storing "NM_SETTING_TARIFF": %s", error->message);
+      g_clear_error (&error);
+      errored = TRUE;
+    }
+
+  if (self->current_device && self->changed_id)
+    g_signal_handler_unblock (self->current_device, self->changed_id);
+  if (self->current_connection && self->connection_changed_id)
+    g_signal_handler_unblock (self->current_connection, self->connection_changed_id);
+
+  /* Only commit the changes if there were no errors. */
+  if (errored)
+    return;
+
+  /* Make sure the application does not exit before the callback is called */
+  g_application_hold (g_application_get_default ());
+
+  nm_remote_connection_commit_changes_async (NM_REMOTE_CONNECTION (connection),
+                                             TRUE, /* save to disk */
+                                             NULL,
+                                             on_network_changes_committed_cb,
+                                             NULL);
+}
+
+/* All three out_* arguments are (optional) and (nullable) */
+static void
+get_active_connection_and_device (CcUpdatesPanel  *self,
+                                  NMDevice       **out_device,
+                                  NMConnection   **out_connection,
+                                  NMAccessPoint  **out_ap)
+{
+  NMActiveConnection *active_connection = NULL;
+  NMConnection *connection = NULL;
+  const GPtrArray *active_devices = NULL;
+  NMAccessPoint *ap = NULL;
+  NMDevice *active_device = NULL;
+
+  active_connection = nm_client_get_primary_connection (self->nm_client);
+
+  /* If no primary connection is already present, try and use the connecting one */
+  if (!active_connection)
+    active_connection = nm_client_get_activating_connection (self->nm_client);
+
+  if (active_connection)
+    {
+      connection = NM_CONNECTION (nm_active_connection_get_connection (active_connection));
+      active_devices = nm_active_connection_get_devices (active_connection);
+
+      if (active_devices && active_devices->len > 0)
+        {
+          /* This array is guaranteed to have only one element */
+          active_device = g_ptr_array_index (active_devices, 0);
+
+          if (NM_IS_DEVICE_WIFI (active_device))
+            ap = nm_device_wifi_get_active_access_point (NM_DEVICE_WIFI (active_device));
+        }
+    }
+
+  g_debug ("%s: got %p, %p, %p", G_STRFUNC, active_device, connection, ap);
+
+  if (out_device)
+    *out_device = active_device;
+
+  if (out_connection)
+    *out_connection = connection;
+
+  if (out_ap)
+    *out_ap = ap;
+}
+
+static const gchar *
+get_wifi_icon_from_strength (NMAccessPoint *ap)
+{
+  guint8 strength;
+
+  if (!ap)
+    return "network-wireless-signal-none-symbolic";
+
+  strength = nm_access_point_get_strength (ap);
+
+  if (strength < 20)
+    return "network-wireless-signal-none-symbolic";
+  else if (strength < 40)
+    return "network-wireless-signal-weak-symbolic";
+  else if (strength < 50)
+    return "network-wireless-signal-ok-symbolic";
+  else if (strength < 80)
+    return "network-wireless-signal-good-symbolic";
+  else
+    return "network-wireless-signal-excellent-symbolic";
+}
+
+static const gchar *
+get_network_status_icon_name (CcUpdatesPanel *self,
+                              NMDevice       *device,
+                              NMAccessPoint  *ap)
+{
+  if (NM_IS_DEVICE_WIFI (device))
+    {
+      switch (nm_client_get_state (self->nm_client))
+        {
+        case NM_STATE_UNKNOWN:
+        case NM_STATE_ASLEEP:
+        case NM_STATE_DISCONNECTING:
+          return "network-wireless-offline-symbolic";
+
+        case NM_STATE_DISCONNECTED:
+          return "network-wireless-offline-symbolic";
+
+        case NM_STATE_CONNECTING:
+          return "network-wireless-acquiring-symbolic";
+
+        case NM_STATE_CONNECTED_LOCAL:
+        case NM_STATE_CONNECTED_SITE:
+          return "network-wireless-no-route-symbolic";
+
+        case NM_STATE_CONNECTED_GLOBAL:
+          return get_wifi_icon_from_strength (ap);
+        }
+    }
+  else
+    {
+      switch (nm_client_get_state (self->nm_client))
+        {
+        case NM_STATE_UNKNOWN:
+        case NM_STATE_ASLEEP:
+        case NM_STATE_DISCONNECTING:
+          return "network-wired-disconnected-symbolic";
+
+        case NM_STATE_DISCONNECTED:
+          return "network-wired-offline-symbolic";
+
+        case NM_STATE_CONNECTING:
+          return "network-wired-acquiring-symbolic";
+
+        case NM_STATE_CONNECTED_LOCAL:
+        case NM_STATE_CONNECTED_SITE:
+          return "network-wired-no-route-symbolic";
+
+        case NM_STATE_CONNECTED_GLOBAL:
+          return "network-wired-symbolic";
+        }
+    }
+
+  return "network-wireless-offline-symbolic";
+}
+
+static void
+schedule_save_tariff (CcUpdatesPanel *self)
+{
+  g_debug ("Scheduling save tariff");
+
+  if (self->save_tariff_timeout_id > 0)
+    g_source_remove (self->save_tariff_timeout_id);
+
+  self->save_tariff_timeout_id = g_timeout_add_seconds (2, save_tariff_cb, self);
+}
+
+static void
+load_tariff_from_connection (CcUpdatesPanel *self,
+                             NMConnection   *connection)
+{
+  g_autoptr(MwtTariff) tariff = NULL;
+  g_autoptr(GError) error = NULL;
+  const gchar *tariff_value = NULL;
+  gboolean tariff_enabled = FALSE;
+
+  g_debug ("Loading tariff from connection");
+
+  if (connection)
+    {
+      NMSettingUser *setting_user;
+      const gchar *tariff_enabled_value = NULL;
+
+      setting_user = ensure_setting_user (connection);
+      g_assert (setting_user != NULL);
+
+      tariff_value = nm_setting_user_get_data (setting_user, NM_SETTING_TARIFF);
+      tariff_enabled_value = nm_setting_user_get_data (setting_user, NM_SETTING_TARIFF_ENABLED);
+
+      if (tariff_enabled_value)
+        tariff_enabled = g_str_equal (tariff_enabled_value, "1");
+    }
+
+  /* Only load the tariff if there is a setting stored */
+  if (tariff_value && *tariff_value != '\0')
+    {
+      g_autoptr(MwtTariffLoader) tariff_loader = NULL;
+      g_autoptr(GVariant) variant = NULL;
+
+      variant = g_variant_parse (NULL, tariff_value, NULL, NULL, &error);
+      if (error)
+        {
+          g_warning ("Error loading tariff: %s", error->message);
+          return;
+        }
+
+      tariff_loader = mwt_tariff_loader_new ();
+      mwt_tariff_loader_load_from_variant (tariff_loader, variant, &error);
+      if (error)
+        {
+          g_warning ("Error loading tariff: %s", error->message);
+          return;
+        }
+
+      tariff = g_object_ref (mwt_tariff_loader_get_tariff (tariff_loader));
+    }
+
+  g_signal_handlers_block_by_func (self->tariff_editor, on_tariff_changed_cb, self);
+  g_signal_handlers_block_by_func (self->scheduled_updates_switch, on_scheduled_updates_switch_changed_cb, self);
+
+  cc_tariff_editor_load_tariff (self->tariff_editor, tariff, &error);
+
+  if (error)
+    g_warning ("Error loading tariff: %s", error->message);
+
+  gtk_switch_set_active (GTK_SWITCH (self->scheduled_updates_switch), tariff_enabled);
+
+  g_signal_handlers_unblock_by_func (self->scheduled_updates_switch, on_scheduled_updates_switch_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->tariff_editor, on_tariff_changed_cb, self);
+}
+
+static void
+load_automatic_updates_from_connection (CcUpdatesPanel *self,
+                                        NMConnection   *connection)
+{
+  gtk_widget_set_sensitive (self->automatic_updates_row, connection != NULL);
+
+  g_signal_handlers_block_by_func (self->automatic_updates_switch, on_automatic_updates_switch_changed_cb, self);
+
+  if (connection)
+    {
+      const gchar * const * keys = NULL;
+      NMSettingUser *setting_user;
+      const gchar *value;
+      gboolean should_save;
+      gboolean enabled;
+
+      setting_user = ensure_setting_user (connection);
+      g_assert (setting_user != NULL);
+
+      /* This is the upgrade path from the old NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED
+       * to NM_SETTING_ALLOW_DOWNLOADS. For now, downloads are always allowed when we're
+       * on a metered connection. */
+      keys = nm_setting_user_get_keys (setting_user, NULL);
+
+      if (g_strv_contains (keys, NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED) &&
+          !g_strv_contains (keys, NM_SETTING_ALLOW_DOWNLOADS))
+        {
+          g_debug ("Upgrading setting from "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED" to "NM_SETTING_ALLOW_DOWNLOADS);
+
+          value = nm_setting_user_get_data (setting_user, NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED);
+          should_save = TRUE;
+        }
+      else
+        {
+          value = nm_setting_user_get_data (setting_user, NM_SETTING_ALLOW_DOWNLOADS);
+          should_save = FALSE;
+        }
+
+      if (value != NULL)
+        {
+          enabled = g_strcmp0 (value, "1") == 0;
+        }
+      else
+        {
+          NMSettingConnection *setting;
+          NMMetered metered;
+
+          /* The default value depends on the metered state of the connection */
+          setting = ensure_setting_connection (connection);
+          g_assert (setting != NULL);
+
+          metered = nm_setting_connection_get_metered (setting);
+          enabled = metered != NM_METERED_YES && metered != NM_METERED_GUESS_YES;
+        }
+
+      gtk_switch_set_active (GTK_SWITCH (self->automatic_updates_switch), enabled);
+
+      if (should_save)
+        schedule_save_tariff (self);
+    }
+  else
+    {
+      gtk_switch_set_active (GTK_SWITCH (self->automatic_updates_switch), FALSE);
+    }
+
+  g_signal_handlers_unblock_by_func (self->automatic_updates_switch, on_automatic_updates_switch_changed_cb, self);
+}
+
+static void
+load_metered_label_from_connection (CcUpdatesPanel *self,
+                                    NMConnection   *connection)
+{
+  NMSettingConnection *setting;
+  NMMetered metered;
+
+  adw_action_row_set_subtitle (self->network_row, NULL);
+
+  if (!connection)
+    return;
+
+  setting = ensure_setting_connection (connection);
+  g_assert (setting != NULL);
+
+  metered = nm_setting_connection_get_metered (setting);
+
+  if (metered == NM_METERED_YES || metered == NM_METERED_GUESS_YES)
+    adw_action_row_set_subtitle (self->network_row, _("Limited data plan connection"));
+  else
+    adw_action_row_set_subtitle (self->network_row, _("Unlimited data plan connection"));
+}
+
+static void
+update_active_network (CcUpdatesPanel *self)
+{
+  NMAccessPoint *ap;
+  NMConnection *connection;
+  NMDevice *device;
+  const gchar *icon_name;
+
+  get_active_connection_and_device (self, &device, &connection, &ap);
+
+  /* Setup the new device... */
+  if (self->current_device != device || self->current_connection != connection)
+    cleanup_signals (self);
+
+  if (g_set_object (&self->current_device, device) && device)
+    {
+      self->changed_id = g_signal_connect_swapped (device,
+                                                   "state-changed",
+                                                   G_CALLBACK (on_network_changed_cb),
+                                                   self);
+    }
+
+  /* ... and the new connection */
+  if (g_set_object (&self->current_connection, connection) && connection)
+    {
+      self->connection_changed_id = g_signal_connect_swapped (connection,
+                                                              "changed",
+                                                              G_CALLBACK (on_network_changed_cb),
+                                                              self);
+    }
+
+  /* Icon */
+  icon_name = get_network_status_icon_name (self, device, ap);
+  gtk_image_set_from_icon_name (GTK_IMAGE (self->network_status_icon), icon_name);
+
+  /* Name */
+  if (ap)
+    {
+      GBytes *ssid = nm_access_point_get_ssid (ap);
+      g_autofree gchar *title = nm_utils_ssid_to_utf8 (g_bytes_get_data (ssid, NULL), g_bytes_get_size (ssid));
+
+      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (self->network_row), title);
+    }
+  else
+    {
+      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (self->network_row),
+                                     connection ? _("Connected") : _("No active connection"));
+    }
+
+  load_metered_label_from_connection (self, connection);
+  load_automatic_updates_from_connection (self, connection);
+  load_tariff_from_connection (self, connection);
+}
+
+static void
+save_connection_settings (CcUpdatesPanel *self)
+{
+  NMConnection *connection;
+  GVariant *tariff_variant;
+  gboolean automatic_updates_enabled;
+  gboolean tariff_enabled;
+
+  g_debug ("Saving connection settings");
+
+  get_active_connection_and_device (self, NULL, &connection, NULL);
+
+  if (connection == NULL)
+    {
+      g_debug ("No network connection to save settings to");
+      return;
+    }
+
+  automatic_updates_enabled = gtk_switch_get_active (GTK_SWITCH (self->automatic_updates_switch));
+  tariff_enabled = gtk_switch_get_active (GTK_SWITCH (self->scheduled_updates_switch));
+  tariff_variant = cc_tariff_editor_get_tariff_as_variant (self->tariff_editor);
+
+  store_automatic_updates_setting (self, connection, automatic_updates_enabled, tariff_enabled, tariff_variant);
+}
+
+
+/*
+ * Callbacks
+ */
+
+static gboolean
+save_tariff_cb (gpointer user_data)
+{
+  CcUpdatesPanel *self = CC_UPDATES_PANEL (user_data);
+
+  save_connection_settings (self);
+  self->save_tariff_timeout_id = 0;
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+on_automatic_updates_switch_changed_cb (GtkSwitch      *sw,
+                                        GParamSpec     *pspec,
+                                        CcUpdatesPanel *self)
+{
+  save_connection_settings (self);
+}
+
+static gboolean
+on_change_network_link_activated_cb (GtkLabel       *label,
+                                     gchar          *uri,
+                                     CcUpdatesPanel *self)
+{
+  g_autoptr(GError) error = NULL;
+  NMDevice *device;
+  CcShell *shell;
+
+  shell = cc_panel_get_shell (CC_PANEL (self));
+
+  get_active_connection_and_device (self, &device, NULL, NULL);
+
+  if (!device || !NM_IS_DEVICE_WIFI (device))
+    cc_shell_set_active_panel_from_id (shell, "network", NULL, &error);
+  else
+    cc_shell_set_active_panel_from_id (shell, "wifi", NULL, &error);
+
+  if (error)
+    {
+      g_warning ("Error activating panel: %s", error->message);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+on_network_changed_cb (CcUpdatesPanel *self)
+{
+  g_debug ("NetworkManager changed state");
+
+  update_active_network (self);
+}
+
+static void
+on_network_changes_committed_cb (GObject      *source,
+                                 GAsyncResult *result,
+                                 gpointer      user_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_application_release (g_application_get_default ());
+
+  nm_remote_connection_commit_changes_finish (NM_REMOTE_CONNECTION (source), result, &error);
+
+  if (error)
+    g_warning ("Error storing connection settings: %s", error->message);
+}
+
+static void
+on_scheduled_updates_switch_changed_cb (GtkSwitch      *sw,
+                                        GParamSpec     *pspec,
+                                        CcUpdatesPanel *self)
+{
+  g_debug ("Scheduled Updates changed state");
+
+  schedule_save_tariff (self);
+}
+
+static void
+on_tariff_changed_cb (CcTariffEditor *tariff_editor,
+                      CcUpdatesPanel *self)
+{
+  g_debug ("The saved tariff changed");
+
+  schedule_save_tariff (self);
+}
+
+
+/*
+ * GObject overrides
+ */
+
+static void
+cc_updates_panel_dispose (GObject *object)
+{
+  CcUpdatesPanel *self = (CcUpdatesPanel *)object;
+
+  if (self->save_tariff_timeout_id > 0)
+    {
+      save_connection_settings (self);
+      g_source_remove (self->save_tariff_timeout_id);
+      self->save_tariff_timeout_id = 0;
+    }
+
+  G_OBJECT_CLASS (cc_updates_panel_parent_class)->dispose (object);
+}
+
+static void
+cc_updates_panel_finalize (GObject *object)
+{
+  CcUpdatesPanel *self = (CcUpdatesPanel *)object;
+
+  cleanup_signals (self);
+
+  g_cancellable_cancel (self->cancellable);
+  g_clear_object (&self->cancellable);
+
+  if (self->nm_client != NULL && self->nm_client_notify_id != 0)
+    {
+      g_signal_handler_disconnect (self->nm_client, self->nm_client_notify_id);
+      self->nm_client_notify_id = 0;
+    }
+  g_clear_object (&self->nm_client);
+
+  G_OBJECT_CLASS (cc_updates_panel_parent_class)->finalize (object);
+}
+
+static void
+cc_updates_panel_set_property (GObject      *object,
+                               guint         prop_id,
+                               const GValue *value,
+                               GParamSpec   *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_PARAMETERS:
+      /* Nothing to do */
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+cc_updates_panel_class_init (CcUpdatesPanelClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->dispose = cc_updates_panel_dispose;
+  object_class->finalize = cc_updates_panel_finalize;
+  object_class->set_property = cc_updates_panel_set_property;
+
+  g_object_class_override_property (object_class, PROP_PARAMETERS, "parameters");
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/updates/cc-updates-panel.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, automatic_updates_row);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, automatic_updates_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_row);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_settings_label);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_status_icon);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, scheduled_updates_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, tariff_editor);
+
+  gtk_widget_class_bind_template_callback (widget_class, on_automatic_updates_switch_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_change_network_link_activated_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_scheduled_updates_switch_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_tariff_changed_cb);
+
+  g_type_ensure (CC_TYPE_TARIFF_EDITOR);
+}
+
+static void
+cc_updates_panel_init (CcUpdatesPanel *self)
+{
+  g_autofree gchar *settings_text = NULL;
+
+  g_resources_register (cc_updates_get_resource ());
+
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* "Change Network Settings" label */
+  settings_text = g_strdup_printf ("<a href=\"\">%s</a>", _("Change Network Settings…"));
+  gtk_label_set_markup (GTK_LABEL (self->network_settings_label), settings_text);
+
+ /* FIXME: Rework this to be async. This will be done at the same time as
+  * reworking all the other panels to be async. */
+  self->nm_client = nm_client_new (NULL, NULL);
+
+  update_active_network (self);
+
+  self->nm_client_notify_id = g_signal_connect_swapped (self->nm_client, "notify", G_CALLBACK (on_network_changed_cb), self);
+}

--- a/panels/updates/cc-updates-panel.h
+++ b/panels/updates/cc-updates-panel.h
@@ -1,0 +1,33 @@
+/* cc-updates-panel.h
+ *
+ * Copyright © 2018 Endless, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Georges Basile Stavracas Neto <georges@endlessm.com>
+ */
+
+#pragma once
+
+#include <shell/cc-panel.h>
+
+G_BEGIN_DECLS
+
+#define CC_TYPE_UPDATES_PANEL (cc_updates_panel_get_type())
+
+G_DECLARE_FINAL_TYPE (CcUpdatesPanel, cc_updates_panel, CC, UPDATES_PANEL, CcPanel)
+
+CcUpdatesPanel *cc_updates_panel_new (void);
+
+G_END_DECLS

--- a/panels/updates/cc-updates-panel.ui
+++ b/panels/updates/cc-updates-panel.ui
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="CcUpdatesPanel" parent="CcPanel">
+    <child type="content">
+      <object class="AdwPreferencesPage">
+
+        <!-- Device header -->
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="can_focus">False</property>
+
+            <child>
+              <object class="AdwActionRow" id="network_row">
+                <property name="can_focus">False</property>
+
+                <child type="prefix">
+                  <object class="GtkImage" id="network_status_icon">
+                    <property name="pixel_size">24</property>
+                    <property name="icon_name">network-wireless-symbolic</property>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkLabel" id="network_settings_label">
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0.0</property>
+                    <signal name="activate-link" handler="on_change_network_link_activated_cb" object="CcUpdatesPanel" swapped="no" />
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwPreferencesGroup">
+            <!-- Automatic Updates -->
+            <child>
+              <object class="AdwActionRow" id="automatic_updates_row">
+                <property name="can_focus">False</property>
+                <property name="activatable-widget">automatic_updates_switch</property>
+                <property name="title" translatable="yes">Automatic Updates</property>
+
+                <child>
+                  <object class="GtkSwitch" id="automatic_updates_switch">
+                    <property name="can_focus">False</property>
+                    <property name="valign">center</property>
+                    <signal name="notify::active" handler="on_automatic_updates_switch_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+            <!-- Schedule Updates -->
+            <child>
+              <object class="AdwActionRow" id="schedule_updates_row">
+                <property name="can_focus">False</property>
+                <property name="sensitive" bind-source="automatic_updates_switch" bind-property="active" bind-flags="default|sync-create" />
+                <property name="activatable-widget">scheduled_updates_switch</property>
+                <property name="title" translatable="yes">Scheduled Updates</property>
+
+                <child>
+                  <object class="GtkSwitch" id="scheduled_updates_switch">
+                    <property name="can_focus">False</property>
+                    <property name="valign">center</property>
+                    <signal name="notify::active" handler="on_scheduled_updates_switch_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+            <child>
+              <object class="AdwPreferencesRow">
+                <property name="visible" bind-source="scheduled_updates_switch" bind-property="active" bind-flags="default|sync-create" />
+                <property name="activatable">False</property>
+                <property name="focusable">False</property>
+                <child>
+                  <object class="GtkRevealer">
+                    <property name="can-focus">False</property>
+                    <property name="transition-type">slide-down</property>
+                    <property name="reveal-child" bind-source="scheduled_updates_switch" bind-property="active" bind-flags="default" />
+
+                    <child>
+                      <object class="CcTariffEditor" id="tariff_editor">
+                        <property name="halign">center</property>
+                        <property name="margin-top">18</property>
+                        <property name="margin-bottom">18</property>
+                        <property name="margin-start">18</property>
+                        <property name="margin-end">18</property>
+                        <signal name="tariff-changed" handler="on_tariff_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                      </object>
+                    </child>
+
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+          </object>
+        </child>
+
+      </object>
+    </child>
+  </template>
+</interface>

--- a/panels/updates/gnome-updates-panel.desktop.in.in
+++ b/panels/updates/gnome-updates-panel.desktop.in.in
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=Updates
+Comment=Schedule automatic updates
+Exec=gnome-control-center updates
+Icon=software-update-available
+Terminal=false
+Type=Application
+NoDisplay=true
+Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
+OnlyShowIn=GNOME;Unity;
+X-GNOME-Bugzilla-Bugzilla=GNOME
+X-GNOME-Bugzilla-Product=gnome-control-center
+X-GNOME-Bugzilla-Component=updates
+X-GNOME-Bugzilla-Version=@VERSION@
+# Translators: those are keywords for the automatic updates control-center panel
+Keywords=Updates;Automatic;Background;Metered;

--- a/panels/updates/meson.build
+++ b/panels/updates/meson.build
@@ -1,0 +1,48 @@
+panels_list += cappletname
+desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
+
+desktop_in = configure_file(
+  input: desktop + '.in.in',
+  output: desktop + '.in',
+  configuration: desktop_conf,
+)
+
+i18n.merge_file(
+  type: 'desktop',
+  input: desktop_in,
+  output: desktop,
+  po_dir: po_dir,
+  install: true,
+  install_dir: control_center_desktopdir,
+)
+
+resource_data = files(
+  'cc-updates-panel.ui',
+  'cc-tariff-editor.ui',
+)
+
+common_sources = gnome.compile_resources(
+  'cc-' + cappletname + '-resources',
+  cappletname + '.gresource.xml',
+  c_name: 'cc_' + cappletname,
+  dependencies: resource_data,
+  export: true,
+)
+
+sources = common_sources + files(
+  'cc-tariff-editor.c',
+  'cc-updates-panel.c',
+)
+
+deps = common_deps + [
+  dependency('libnm', version: '>= 1.8.0'),
+  dependency('libnma', version: '>= 1.8.0'),
+  dependency('mogwai-tariff-0', version: '>=0.1.0'),
+]
+
+panels_libs += static_library(
+  cappletname,
+  sources: sources,
+  include_directories: top_inc,
+  dependencies: deps,
+)

--- a/panels/updates/updates.gresource.xml
+++ b/panels/updates/updates.gresource.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/gnome/control-center/updates">
+    <file preprocess="xml-stripblanks">cc-tariff-editor.ui</file>
+    <file preprocess="xml-stripblanks">cc-updates-panel.ui</file>
+  </gresource>
+</gresources>

--- a/shell/cc-panel-list.c
+++ b/shell/cc-panel-list.c
@@ -430,6 +430,7 @@ static const gchar * const panel_order[] = {
   "reset-settings",
   "datetime",
   "info-overview",
+  "updates",
 };
 
 static guint

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -63,6 +63,7 @@ extern GType cc_sound_panel_get_type (void);
 extern GType cc_bolt_panel_get_type (void);
 #endif /* BUILD_THUNDERBOLT */
 extern GType cc_ua_panel_get_type (void);
+extern GType cc_updates_panel_get_type (void);
 extern GType cc_user_panel_get_type (void);
 #ifdef BUILD_WACOM
 extern GType cc_wacom_panel_get_type (void);
@@ -138,6 +139,7 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("thunderbolt",      cc_bolt_panel_get_type,                 NULL),
 #endif
   PANEL_TYPE("universal-access", cc_ua_panel_get_type,                   NULL),
+  PANEL_TYPE("updates",          cc_updates_panel_get_type,              NULL),
   PANEL_TYPE("usage",            cc_usage_panel_get_type,                NULL),
   PANEL_TYPE("user-accounts",    cc_user_panel_get_type,                 NULL),
 #ifdef BUILD_WACOM


### PR DESCRIPTION
- basic port from gtk3 [endlessm's gnome-control-center updates panel](https://github.com/endlessm/gnome-control-center/tree/master/panels/updates) to gtk4
- building requires [mogwai](https://github.com/endlessm/mogwai) as dependency

##  to-do:
- [ ]  package `mogwai` for stable
- [ ]  patch `gnome-software` and enable `mogwai` during build
- [ ]  patch `gnome-software` to remove _Update-Prefrences_ row
- [ ]  Add Automatic Update Notifications `GtkSwitch`
- [ ]  Move _Software Updates_ row from **About** to **Updates**

cc: @mirkobrombin @matbme 