### PR TITLE
feat:[close #27] Add updates utility to about screen

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ keyboard-Allow-disabling-alternate-characters-key.patch
 debian/Expose-touchpad-settings-if-synaptics-is-in-use.patch
 debian/Debian-s-adduser-doesn-t-allow-uppercase-letters-by-defau.patch
 debian/Ignore-result-of-test-network-panel.patch
+vanillaos/vanilla-updates-utility.patch

--- a/debian/patches/vanillaos/vanilla-updates-utility.patch
+++ b/debian/patches/vanillaos/vanilla-updates-utility.patch
@@ -1,0 +1,76 @@
+diff --git a/panels/system/about/cc-about-page.c b/panels/system/about/cc-about-page.c
+index 80969f0bf..46a9d231d 100644
+--- a/panels/system/about/cc-about-page.c
++++ b/panels/system/about/cc-about-page.c
+@@ -83,38 +83,9 @@ about_page_setup_overview (CcAboutPage *self)
+ }
+ 
+ static gboolean
+-does_gnome_software_allow_updates (void)
++does_vos_updates_utility_exist (void)
+ {
+-  const gchar *schema_id  = "org.gnome.software";
+-  GSettingsSchemaSource *source;
+-  g_autoptr(GSettingsSchema) schema = NULL;
+-  g_autoptr(GSettings) settings = NULL;
+-
+-  source = g_settings_schema_source_get_default ();
+-
+-  if (source == NULL)
+-    return FALSE;
+-
+-  schema = g_settings_schema_source_lookup (source, schema_id, FALSE);
+-
+-  if (schema == NULL)
+-    return FALSE;
+-
+-  settings = g_settings_new (schema_id);
+-  return g_settings_get_boolean (settings, "allow-updates");
+-}
+-
+-static gboolean
+-does_gnome_software_exist (void)
+-{
+-  g_autofree gchar *path = g_find_program_in_path ("gnome-software");
+-  return path != NULL;
+-}
+-
+-static gboolean
+-does_gpk_update_viewer_exist (void)
+-{
+-  g_autofree gchar *path = g_find_program_in_path ("gpk-update-viewer");
++  g_autofree gchar *path = g_find_program_in_path ("vanilla-updates-utility");
+   return path != NULL;
+ }
+ 
+@@ -135,16 +106,16 @@ cc_about_page_open_software_update (CcAboutPage *self)
+   gboolean ret;
+   char *argv[3];
+ 
+-  if (does_gnome_software_exist ())
++  if (does_vos_updates_utility_exist ())
+     {
+-      argv[0] = "gnome-software";
+-      argv[1] = "--mode=updates";
++      argv[0] = "vanilla-updates-utility";
++      argv[1] = "--embedded";
+       argv[2] = NULL;
+     }
+   else
+     {
+-      argv[0] = "gpk-update-viewer";
+-      argv[1] = NULL;
++      g_warning ("Vanilla update utility not found!");
++      return;
+     }
+   ret = g_spawn_async (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
+   if (!ret)
+@@ -235,7 +206,7 @@ cc_about_page_init (CcAboutPage *self)
+ 
+   gtk_widget_init_template (GTK_WIDGET (self));
+ 
+-  if ((!does_gnome_software_exist () || !does_gnome_software_allow_updates ()) && !does_gpk_update_viewer_exist ())
++  if (!does_vos_updates_utility_exist ())
+     gtk_widget_set_visible (GTK_WIDGET (self->software_updates_group), FALSE);
+ 
+   about_page_setup_overview (self);


### PR DESCRIPTION
Launch vanilla-updates-utility instead of gnome-software in the About panel of gnome control center

closes #27 