### PR TITLE
feat:[close #28] Add prime utility to display panel

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ debian/Expose-touchpad-settings-if-synaptics-is-in-use.patch
 debian/Debian-s-adduser-doesn-t-allow-uppercase-letters-by-defau.patch
 debian/Ignore-result-of-test-network-panel.patch
 vanillaos/vanilla-updates-utility.patch
+vanillaos/vanilla-prime-utility.patch

--- a/debian/patches/vanilla-prime-utility.patch
+++ b/debian/patches/vanilla-prime-utility.patch
@@ -1,0 +1,106 @@
+diff --git a/panels/display/cc-display-panel.c b/panels/display/cc-display-panel.c
+index c2eb37d41..b6ef5a94f 100644
+--- a/panels/display/cc-display-panel.c
++++ b/panels/display/cc-display-panel.c
+@@ -103,6 +103,7 @@ struct _CcDisplayPanel
+   AdwNavigationView *nav_view;
+   AdwComboRow    *primary_display_row;
+   AdwPreferencesGroup *single_display_settings_group;
++  AdwPreferencesGroup *prime_utility_row;
+ 
+   GtkShortcutController *toplevel_shortcuts;
+   GtkShortcut *escape_shortcut;
+@@ -553,6 +554,37 @@ on_toplevel_escape_pressed_cb (GtkWidget      *widget,
+   return GDK_EVENT_PROPAGATE;
+ }
+ 
++static gboolean
++does_prime_utility_exist (void)
++{
++  g_autofree gchar *path = g_find_program_in_path ("vanilla-prime-utility");
++  return path != NULL;
++}
++
++static void
++cc_display_panel_prime (CcDisplayPanel *self)
++{
++  g_autoptr (GError) error = NULL;
++  gboolean ret;
++  char *argv[3];
++
++  if (does_prime_utility_exist ())
++    {
++      argv[0] = "vanilla-prime-utility";
++      argv[1] = "--embedded";
++      argv[2] = NULL;
++    }
++  else
++    {
++      g_warning ("Vanilla prime utility not found!");
++      return;
++    }
++
++  ret = g_spawn_async (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
++  if (!ret)
++    g_warning ("Failed to spawn %s: %s", argv[0], error->message);
++}
++
+ static void
+ cc_display_panel_constructed (GObject *object)
+ {
+@@ -619,6 +651,7 @@ cc_display_panel_class_init (CcDisplayPanelClass *klass)
+   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, primary_display_row);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, single_display_settings_group);
+   gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, toplevel_shortcuts);
++  gtk_widget_class_bind_template_child (widget_class, CcDisplayPanel, prime_utility_row);
+ 
+   gtk_widget_class_bind_template_callback (widget_class, apply_current_configuration);
+   gtk_widget_class_bind_template_callback (widget_class, cancel_current_configuration);
+@@ -626,6 +659,7 @@ cc_display_panel_class_init (CcDisplayPanelClass *klass)
+   gtk_widget_class_bind_template_callback (widget_class, on_primary_display_selected_item_changed_cb);
+   gtk_widget_class_bind_template_callback (widget_class, on_screen_changed);
+   gtk_widget_class_bind_template_callback (widget_class, on_toplevel_escape_pressed_cb);
++  gtk_widget_class_bind_template_callback (widget_class, cc_display_panel_prime);
+ }
+ 
+ static void
+@@ -1122,6 +1156,9 @@ cc_display_panel_init (CcDisplayPanel *self)
+   else
+     g_clear_object (&self->up_client);
+ 
++  if (!does_prime_utility_exist ())
++    gtk_widget_set_visible (GTK_WIDGET (self->prime_utility_row), false);
++
+   g_signal_connect (self, "map", G_CALLBACK (mapped_cb), NULL);
+ 
+   cc_object_storage_create_dbus_proxy (G_BUS_TYPE_SESSION,
+diff --git a/panels/display/cc-display-panel.ui b/panels/display/cc-display-panel.ui
+index b7eb9e9e6..2bfb8f3ac 100644
+--- a/panels/display/cc-display-panel.ui
++++ b/panels/display/cc-display-panel.ui
+@@ -165,6 +165,25 @@
+                       </object>
+                     </child>
+ 
++                    <!-- Prime Utility -->
++                    <child>
++                      <object class="AdwPreferencesGroup" id="prime_utility_row">
++                        <child>
++                          <object class="AdwActionRow">
++                            <property name="activatable">True</property>
++                            <property name="title" translatable="yes">Prime Utility</property>
++                            <property name="use-underline">True</property>
++                            <signal name="activated" handler="cc_display_panel_prime" swapped="yes"/>
++                            <child type="suffix">
++                              <object class="GtkImage">
++                                <property name="valign">center</property>
++                                <property name="icon-name">adw-external-link-symbolic</property>
++                              </object>
++                            </child>
++                          </object>
++                        </child>
++                      </object>
++                    </child>
+                   </object>
+                 </property>
+               </object>


### PR DESCRIPTION
Adds a button to launch vanilla-prime-utility from the display panel

closes #28 