### PR TITLE
fixes incorrect assignment

### DIFF
--- a/debian/patches/vanillaos/vanilla-prime-utility.patch
+++ b/debian/patches/vanillaos/vanilla-prime-utility.patch
@@ -22,7 +22,7 @@ index f40b2cf..a179c32 100644
 +            title: _("GPU Profile Management (PRIME)");
 +            activatable: true;
 +            use-underline: true;
-+            activated => $c_display_panel_prime(template);
++            activated => $cc_display_panel_prime(template);
 +
 +            [suffix]
 +            Gtk.Image {

--- a/debian/patches/vanillaos/vanilla-prime-utility.patch
+++ b/debian/patches/vanillaos/vanilla-prime-utility.patch
@@ -42,7 +42,7 @@ index d9de82c..d6beb69 100644
    AdwNavigationPage *display_settings_page;
    AdwComboRow    *primary_display_row;
    AdwPreferencesGroup *single_display_settings_group;
-+  AdwPreferencesGroup *prime_utility_row;
++  AdwActionRow *prime_utility_row;
  
    GtkShortcut *escape_shortcut;
  


### PR DESCRIPTION
prime_utility_row has type Adw.ActionRow, so using Adw.PreferencesGroup selected an incorrect widget.